### PR TITLE
Added Chat Command for interacting with Gold API

### DIFF
--- a/game/scripts/vscripts/gamemode.lua
+++ b/game/scripts/vscripts/gamemode.lua
@@ -165,7 +165,7 @@ function GameMode:InitGameMode()
   -- Commands can be registered for debugging purposes or as functions that can be called by the custom Scaleform UI
   -- Convars:RegisterCommand( "command_example", Dynamic_Wrap(GameMode, 'ExampleConsoleCommand'), "A console command example", FCVAR_CHEAT )
 
-  DebugPrint('[BAREBONES] Done loading Barebones gamemode!\n\n')
+  DebugPrint('[BAREBONES] Done loading Barebones gamemode!')
 end
 
 -- This is an example console command

--- a/game/scripts/vscripts/internal/gamemode.lua
+++ b/game/scripts/vscripts/internal/gamemode.lua
@@ -140,7 +140,7 @@ function GameMode:_InitGameMode()
   self.bSeenWaitForPlayers = false
   self.vUserIds = {}
 
-  DebugPrint('[BAREBONES] Done loading Barebones gamemode!\n\n')
+  DebugPrint('[BAREBONES] Done loading Barebones gamemode!')
   GameMode._reentrantCheck = true
   GameMode:InitGameMode()
   GameMode._reentrantCheck = false


### PR DESCRIPTION
Added "-goldc" Chat Command
#### Usage
* `-goldc add <amount>`
* `-goldc set <amount>`
* `-goldc remove <amount>`
* `-goldc modify <amount>`
* `-goldc clear`

##### Found Bugs: 1
With our current implementation we use to interact with the vanilla shop you cannot reduced the amount of gold via the Gold API below 50000 