### PR TITLE
Rewrote custom ability level requirements to use an ExecuteOrder filter (fixes #147)

### DIFF
--- a/content/panorama/layout/custom_game/custom_ui_manifest.xml
+++ b/content/panorama/layout/custom_game/custom_ui_manifest.xml
@@ -3,6 +3,7 @@
     <include src="file://{resources}/scripts/playertables/playertables_base.js" />
     <include src="file://{resources}/scripts/custom_game/gold.js" />
     <include src="file://{resources}/scripts/custom_game/pointsmanager.js" />
+    <include src="file://{resources}/scripts/custom_game/abilitylevels.js" />
     <include src="file://{resources}/scripts/util.js" />
   </scripts>
   <script>

--- a/content/panorama/scripts/custom_game/abilitylevels.js
+++ b/content/panorama/scripts/custom_game/abilitylevels.js
@@ -1,0 +1,13 @@
+'use strict'
+
+(function () {
+  GameEvents.Subscribe("ability_level_error", DisplayAbilityLevelError)
+}())
+
+function DisplayAbilityLevelError (data) {
+  // Localise hero level requirement error message and insert hero level number
+  var errorMessageText = $.Localize("#dota_hud_error_ability_cant_upgrade_hero_level").replace("%s1", data.requiredLevel)
+
+  var errorData = {reason: 80, message: errorMessageText}
+  GameEvents.SendEventClientSide("dota_hud_error_message", errorData)
+}

--- a/game/scripts/vscripts/components/abilities/level.lua
+++ b/game/scripts/vscripts/components/abilities/level.lua
@@ -6,10 +6,10 @@ if AbilityLevels == nil then
 end
 
 function AbilityLevels:Init ()
-  GameRules:GetGameModeEntity():SetExecuteOrderFilter(Dynamic_Wrap(AbilityLevels, "ExecuteOrderFilterTest"), nil)
+  GameRules:GetGameModeEntity():SetExecuteOrderFilter(Dynamic_Wrap(AbilityLevels, "FilterAbilityUpgradeOrder"), nil)
 end
 
-function AbilityLevels:ExecuteOrderFilterTest (keys)
+function AbilityLevels:FilterAbilityUpgradeOrder (keys)
   -- Immediately return true if intercepted order isn't an ability upgrade order
   if keys.order_type ~= 11 then
     return true

--- a/game/scripts/vscripts/components/abilities/level.lua
+++ b/game/scripts/vscripts/components/abilities/level.lua
@@ -11,7 +11,7 @@ end
 
 function AbilityLevels:FilterAbilityUpgradeOrder (keys)
   -- Immediately return true if intercepted order isn't an ability upgrade order
-  if keys.order_type ~= 11 then
+  if keys.order_type ~= DOTA_UNIT_ORDER_TRAIN_ABILITY then
     return true
   end
 


### PR DESCRIPTION
This prevents unwanted firing of ability OnUpgrade events.
Also added code to display a HUD error message when ability can't be upgraded due to custom level requirements.

P.S. I don't know much about these filter things and ExecuteOrder filters seem to intercept pretty much all player commands, so something could potentially break in a pretty weird way if I messed something up.